### PR TITLE
Fix withdrawal bug

### DIFF
--- a/refrigerant/management/commands/withdraw.py
+++ b/refrigerant/management/commands/withdraw.py
@@ -15,19 +15,23 @@ class Command(BaseCommand):
     def run_simulation(self):
         barrier = threading.Barrier(2)
 
-        def user1():
+        def withdraw_refrigerant(user, amount):
             with transaction.atomic():
                 barrier.wait()
                 vessel = Vessel.objects.select_for_update().get(id=1)
-                vessel.content -= 10.0
+                if vessel.content < amount:
+                    self.stderr.write(f"{user}: Not enough refrigerant!")
+                    return
+                vessel.content -= amount
                 vessel.save()
+                self.stdout.write(f"{user}: Withdrawn {amount} kg")
+
+        def user1():
+            withdraw_refrigerant('user1', 10.0)
 
         def user2():
-            with transaction.atomic():
-                barrier.wait()
-                vessel = Vessel.objects.select_for_update().get(id=1)
-                vessel.content -= 10.0
-                vessel.save()
+            withdraw_refrigerant('user2', 10.0)
+
 
         t1 = threading.Thread(target=user1)
         t2 = threading.Thread(target=user2)

--- a/refrigerant/management/commands/withdraw.py
+++ b/refrigerant/management/commands/withdraw.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from ...models import Vessel
 import threading
 
@@ -15,16 +16,18 @@ class Command(BaseCommand):
         barrier = threading.Barrier(2)
 
         def user1():
-            barrier.wait()
-            vessel = Vessel.objects.get(id=1)
-            vessel.content -= 10.0
-            vessel.save()
+            with transaction.atomic():
+                barrier.wait()
+                vessel = Vessel.objects.select_for_update().get(id=1)
+                vessel.content -= 10.0
+                vessel.save()
 
         def user2():
-            barrier.wait()
-            vessel = Vessel.objects.get(id=1)
-            vessel.content -= 10.0
-            vessel.save()
+            with transaction.atomic():
+                barrier.wait()
+                vessel = Vessel.objects.select_for_update().get(id=1)
+                vessel.content -= 10.0
+                vessel.save()
 
         t1 = threading.Thread(target=user1)
         t2 = threading.Thread(target=user2)


### PR DESCRIPTION
This PR addresses the issue of simultaneous withdrawals from a vessel in the refrigerant simulation.

**Changes made:**

- **Refactored Code:** Introduced the withdraw_refrigerant function to eliminate duplicated logic and make the code more maintainable.
- **Transaction Handling:** Used `transaction.atomic()` and `select_for_update()` to ensure that concurrent withdrawals are handled correctly, preventing partial updates.
- **Availability Check:** Added a check to verify that the vessel has enough refrigerant before processing the withdrawal, preventing database exceptions and improving error handling.
- **User Feedback:** Added an error messages to provide clearer feedback when a withdrawal cannot be processed due to insufficient refrigerant.